### PR TITLE
Clarify hacks doc

### DIFF
--- a/xglfs_truncate.c
+++ b/xglfs_truncate.c
@@ -28,12 +28,10 @@ int xglfs_truncate(const char* _path, off_t _length)
 	int ret = 0;
 
 	/*
-		return glfs_truncate(XGLFS_STATE->fs, _path, _length);
-
-		I thought so. But, unexpectedly, it does not work
-		because glfs_truncate() is not provided by GlusterFS libraries.
-
-		Workaround goes below.
+	 * glfs_truncate() is still missing.
+	 * See http://review.gluster.org/#/c/13927/
+	 *
+	 * The code below is considered to be temporary workaround.
 	*/
 
 	glfs_fd_t* fd = glfs_open(XGLFS_STATE->fs, _path, O_CREAT | O_WRONLY);

--- a/xglfs_utimens.c
+++ b/xglfs_utimens.c
@@ -26,6 +26,12 @@
 int xglfs_utimens(const char* _path, const struct timespec _tv[2])
 {
 	int ret = 0;
+
+	/*
+	 * Copy is needed to remove const qualifier.
+	 * Probably, this is a bug in GFAPI.
+	 * glfs_lutimes() should declare 3rd argument as const.
+	 */
 	struct timespec tv[2];
 	tv[0] = _tv[0];
 	tv[1] = _tv[1];


### PR DESCRIPTION
This PR clarifies hacks used for xglfs_truncate() and xglfs_utimens() implementations.
